### PR TITLE
fix spelling mistake (neovim)

### DIFF
--- a/neovim/python3.conf.sh
+++ b/neovim/python3.conf.sh
@@ -2,7 +2,7 @@
 
 _CONFIG_DIR="$HOME/.config/nvim"
 
-cp ./conf/python/{init.vim,local_bundles.vim,local_init.vim} $_CONFIG_DIR
+cp ./conf/python3/{init.vim,local_bundles.vim,local_init.vim} $_CONFIG_DIR
 
 ### python3 linter
 


### PR DESCRIPTION
Solved the problem that the CP statement of neovim/python3.conf.sh was not executed.
Please review.